### PR TITLE
Changes for making cloudant integration work and replace uname-pwd authentication with iamapikey

### DIFF
--- a/src/main/java/com/ibm/inventory_management/controllers/StockItemController.java
+++ b/src/main/java/com/ibm/inventory_management/controllers/StockItemController.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.context.annotation.Lazy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +18,7 @@ public class StockItemController {
 
     private final StockItemApi service;
 
-    public StockItemController(StockItemApi service) {
+    public StockItemController(@Lazy StockItemApi service) {
         this.service = service;
     }
 

--- a/src/main/java/com/ibm/inventory_management/services/CloudantApi.java
+++ b/src/main/java/com/ibm/inventory_management/services/CloudantApi.java
@@ -26,8 +26,9 @@ public class CloudantApi {
 
         return ClientBuilder
                 .url(url)
-                .username(config.getUsername())
-                .password(config.getPassword())
+                .iamApiKey(config.getApikey())
+                //.username(config.getUsername())
+                //.password(config.getPassword())
                 .build();
     }
 }

--- a/src/main/java/com/ibm/inventory_management/services/StockItemService.java
+++ b/src/main/java/com/ibm/inventory_management/services/StockItemService.java
@@ -3,23 +3,51 @@ package com.ibm.inventory_management.services;
 import java.io.IOException;
 import java.util.List;
 import javax.annotation.PostConstruct;
+import java.net.URL;
+import java.net.MalformedURLException;
 
 import com.cloudant.client.api.CloudantClient;
+import com.cloudant.client.api.ClientBuilder;
 import com.cloudant.client.api.Database;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 
 import com.ibm.inventory_management.config.CloudantConfig;
 import com.ibm.inventory_management.models.StockItem;
 
+
+
+
+//@Profile("!mock")
+
 @Service
-@Profile("!mock")
+@Primary
 public class StockItemService implements StockItemApi {
+    @Bean
+    public static CloudantClient buildCloudant(CloudantConfig config) throws CloudServicesException { 
+        System.out.println("Config: " + config);
+        URL url = null;
+        try {
+            url = new URL(config.getUrl());
+        } catch (MalformedURLException e) {
+            throw new CloudServicesException("Invalid service URL specified", e);
+        }
+       
+       return ClientBuilder
+                .url(url)
+                .iamApiKey(config.getApikey())
+                //.username(config.getUsername())
+                //.password(config.getPassword())
+                .build();
+    }
     private CloudantConfig config;
     private CloudantClient client;
     private Database db = null;
 
-    public StockItemService(CloudantConfig config, CloudantClient client) {
+    public StockItemService(CloudantConfig config, @Lazy CloudantClient client) {
         this.config = config;
         this.client = client;
     }


### PR DESCRIPTION
1.Made the following changes to make cloudant integration work:
- Created a bean for CloudantClient
- Used @Lazy to resolve circular dependency.

2. Replaced the authentication from username and password to iamapikey as only the cloudant with  authentication method "IAM and legacy credentials" will have password field as part of credentials whereas iamapikey is provided in all authentication methods. 
