### PR TITLE
primary annotation  changes for mock service

### DIFF
--- a/src/main/java/com/ibm/inventory_management/services/StockItemMockService.java
+++ b/src/main/java/com/ibm/inventory_management/services/StockItemMockService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import com.ibm.inventory_management.models.StockItem;
 
 @Service
+@Primary
 @Profile("mock")
 public class StockItemMockService implements StockItemApi {
     @Override

--- a/src/main/java/com/ibm/inventory_management/services/StockItemService.java
+++ b/src/main/java/com/ibm/inventory_management/services/StockItemService.java
@@ -23,8 +23,7 @@ import com.ibm.inventory_management.models.StockItem;
 
 //@Profile("!mock")
 
-@Service
-@Primary
+
 public class StockItemService implements StockItemApi {
     @Bean
     public static CloudantClient buildCloudant(CloudantConfig config) throws CloudServicesException { 


### PR DESCRIPTION
As per the "Part 1" learning journey documentation. Cloudant integration not need. So make the Mock service as primary service changed annotation 